### PR TITLE
fix post ordering 1.0.4 back to top

### DIFF
--- a/content/posts/4.widgets.md
+++ b/content/posts/4.widgets.md
@@ -1,7 +1,7 @@
 ---
 title: Widgets - Floating and overlay
 date: July 10, 2022
-version: "1.04"
+version: "1.0.4"
 ---
 
 ![widgets](/widgets.png)


### PR DESCRIPTION
there was a typo messing this up so quick fix now the newest change will go back at the top.

types as v1.04 instead of v1.0.4 which sent the post to the bottom so just a quick fix.